### PR TITLE
Add Telegram bot to fetch tennis surface statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Tennis Bot
+
+Bot do Telegram que consulta a Tennis API (RapidAPI) para exibir
+estatísticas de jogadores separadas por tipo de piso.
+
+## Configuração
+
+Defina as seguintes variáveis de ambiente antes de executar:
+
+```bash
+export TELEGRAM_TOKEN="seu_token"
+export API_KEY="sua_chave_rapidapi"
+export API_HOST="tennis-api-atp-wta-itf.p.rapidapi.com"
+```
+
+## Instalação
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso
+
+Execute o bot:
+
+```bash
+python main.py
+```
+
+No Telegram, envie uma mensagem com quatro linhas:
+
+```
+05/09
+16:10
+Novak Djokovic
+Carlos Alcaraz
+```
+
+O bot retornará as estatísticas de vitórias/derrotas de cada jogador por
+piso (hard, clay, etc.).
+
+## Observações
+
+- Os nomes dos jogadores são pesquisados via endpoint `/tennis/v2/search`.
+- Apenas as estatísticas disponíveis na API serão exibidas.
+- Caso algum jogador não seja encontrado, será exibida mensagem de dados
+indisponíveis.

--- a/config.py
+++ b/config.py
@@ -1,6 +1,16 @@
 import os
 
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+
+def require_env(name: str) -> str:
+    """Return environment variable or raise RuntimeError if missing."""
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Environment variable {name} is required")
+    return value
+
+
+TELEGRAM_TOKEN = require_env("TELEGRAM_TOKEN")
+API_KEY = require_env("API_KEY")
+API_HOST = require_env("API_HOST")
+
 TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
-API_KEY = os.getenv("API_KEY")
-API_HOST = os.getenv("API_HOST")

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Dict, Optional
+
+import requests
+
+from config import API_KEY, API_HOST
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = f"https://{API_HOST}"
+
+
+def _request(endpoint: str, params: dict | None = None) -> dict:
+    headers = {
+        "X-RapidAPI-Key": API_KEY,
+        "X-RapidAPI-Host": API_HOST,
+    }
+    url = f"{BASE_URL}/{endpoint}"
+    try:
+        resp = requests.get(url, headers=headers, params=params, timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # broad catch to log any issue
+        logger.error("API request failed: %s", exc)
+        return {}
+
+
+def buscar_id_jogador(nome: str) -> Optional[int]:
+    """Return the first player ID that matches the provided name."""
+    data = _request("tennis/v2/search", {"search": nome})
+    players = (
+        data.get("players")
+        or data.get("results")
+        or []
+    )
+    for player in players:
+        player_id = player.get("id") or player.get("playerId")
+        if player_id:
+            return player_id
+    logger.info("No player found for name '%s'", nome)
+    return None
+
+
+def buscar_stats_por_piso(player_id: int) -> Dict[str, Dict[str, int]]:
+    """Fetch win/loss statistics by surface for a player."""
+    data = _request(f"tennis/v2/atp/player/surface-summary/{player_id}")
+    stats = {}
+    # The actual structure may vary; try to be defensive.
+    surfaces = (
+        data.get("player", {}).get("surfaceStats")
+        or data.get("surfaces")
+        or data.get("surfaceSummaries")
+        or []
+    )
+    for item in surfaces:
+        surface = item.get("surface") or item.get("name")
+        if not surface:
+            continue
+        stats[surface.lower()] = {
+            "wins": item.get("wins") or item.get("win"),
+            "losses": item.get("losses") or item.get("loss"),
+        }
+    return stats
+
+
+def buscar_stats_jogador(nome: str) -> Optional[Dict[str, Dict[str, int]]]:
+    player_id = buscar_id_jogador(nome)
+    if player_id is None:
+        return None
+    return buscar_stats_por_piso(player_id)
+

--- a/main.py
+++ b/main.py
@@ -1,40 +1,58 @@
-import time
-from data_fetcher import buscar_partidas_ao_vivo, buscar_partidas_pre_jogo
-from rules import avaliar_ao_vivo, avaliar_pre_jogo
-from alerts import enviar_alerta_ao_vivo, enviar_alerta_pre_jogo
+import logging
+from typing import Dict, Optional
 
-def executar_bot():
-    print("🚀 Iniciando análise de partidas com dados reais...")
-    while True:
-        try:
-            print("\n🔎 Analisando PRÉ-JOGO:")
-            pre_jogo = buscar_partidas_pre_jogo()
-            if not pre_jogo:
-                print("Nenhuma partida pré-jogo encontrada.")
-            for partida in pre_jogo:
-                print(f"➡️ {partida['jogador1']} vs {partida['jogador2']} - 1º Saque: {partida['primeiro_saque']}%, BP: {partida['bp_convertidos']}%, TMAP: {partida['diferenca_tmap']}")
-                if avaliar_pre_jogo(partida):
-                    print("✅ Enviando alerta pré-jogo")
-                    enviar_alerta_pre_jogo(partida)
-                else:
-                    print("❌ Não atende os critérios pré-jogo")
+from telegram.ext import ApplicationBuilder, MessageHandler, ContextTypes, filters
 
-            print("\n🎾 Analisando AO VIVO:")
-            ao_vivo = buscar_partidas_ao_vivo()
-            if not ao_vivo:
-                print("Nenhuma partida ao vivo encontrada.")
-            for partida in ao_vivo:
-                print(f"➡️ {partida['jogador1']} vs {partida['jogador2']} - Placar: {partida['pontuacao']}, 1º Saque: {partida['primeiro_saque']}%, TMAP: {partida['diferenca_tmap']}")
-                if avaliar_ao_vivo(partida):
-                    print("✅ Enviando alerta ao vivo")
-                    enviar_alerta_ao_vivo(partida)
-                else:
-                    print("❌ Não atende os critérios ao vivo")
+from config import TELEGRAM_TOKEN
+from data_fetcher import buscar_stats_jogador
 
-        except Exception as e:
-            print("Erro:", e)
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
 
-        time.sleep(90)
+
+def formatar_stats(nome: str, stats: Optional[Dict[str, Dict[str, int]]]) -> str:
+    if not stats:
+        return f"{nome}: dados indisponíveis."
+
+    linhas = [f"{nome}"]
+    for superficie, info in stats.items():
+        wins = info.get("wins", "?")
+        losses = info.get("losses", "?")
+        linhas.append(f"  • {superficie.title()}: {wins}-{losses}")
+    return "\n".join(linhas)
+
+
+async def partida_handler(update, context: ContextTypes.DEFAULT_TYPE):
+    texto = update.message.text.strip()
+    linhas = texto.splitlines()
+    if len(linhas) != 4:
+        await update.message.reply_text(
+            "Formato inválido. Envie:\nDATA\nHORA\nJOGADOR1\nJOGADOR2"
+        )
+        return
+
+    data, hora, jogador1, jogador2 = linhas
+    stats1 = buscar_stats_jogador(jogador1)
+    stats2 = buscar_stats_jogador(jogador2)
+
+    mensagem = (
+        f"📅 {data} ⏰ {hora}\n\n"
+        f"{formatar_stats(jogador1, stats1)}\n\n"
+        f"{formatar_stats(jogador2, stats2)}"
+    )
+    await update.message.reply_text(mensagem)
+
+
+def main():
+    app = ApplicationBuilder().token(TELEGRAM_TOKEN).build()
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, partida_handler))
+    logger.info("Bot iniciado. Aguardando mensagens...")
+    app.run_polling()
+
 
 if __name__ == "__main__":
-    executar_bot()
+    main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests
-python-telegram-bot==13.15
+requests==2.31.0
+python-telegram-bot==20.7


### PR DESCRIPTION
## Summary
- validate required environment variables
- implement data fetcher querying RapidAPI for player surface stats
- add Telegram bot responding with stats per surface

## Testing
- `python -m py_compile config.py data_fetcher.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb09b25ac88322a7d2bfd816ec4273